### PR TITLE
DOC: Fix IJ journal description link and authors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "itk-fastbilateral"
 version = "0.1.0"
-description = "Faster implementation of the itkBilateralImageFilter. From the insight journal submission: https://www.insight-journal.org/browse/publication/692."
+description = "Faster implementation of the itkBilateralImageFilter. From the insight journal submission: https://www.insight-journal.org/browse/publication/692"
 readme = "README.rst"
 license = {file = "LICENSE"}
 authors = [
-    { name = "Pablo Hernandez Cerdan", email = "pablo.hernandez.cerdan@outlook.com" },
+    { name = "Jordan Woehr and Pablo Hernandez Cerdan", email = "pablo.hernandez.cerdan@outlook.com" },
 ]
 keywords = [
     "itk",


### PR DESCRIPTION
Fix IJ journal description link and authors:
- Remove the trailing period to allow the link to work properly.
- Add the original IJ author to the authors list.